### PR TITLE
v0.6 - methods for epsilon and omega

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@
 - Added `hesse_array` method that allows calculating the hesse matrix (for an
   arbitrary number of field-space dimensions) at all points in a given field-
   space array.
+- added functionality to calculate the turn rate $\omega$ in situations where
+  such a calculation is valid ($\delta\ll1$).
+- added functionality to calculate the hesse matrix for a whole range of field
+  space values at once.
 - Upgraded numpy 0.19 -> 0.20
 - Upgraded PyO3 0.19 -> 0.20
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,8 +9,8 @@
 - Added `hesse_array` method that allows calculating the hesse matrix (for an
   arbitrary number of field-space dimensions) at all points in a given field-
   space array.
-- added functionality to calculate the turn rate $\omega$ in situations where
-  such a calculation is valid ($\delta\ll1$).
+- added functionality to calculate the turn rate $\omega$ under the assumption
+  that the slow-roll parameters are small.
 - added functionality to calculate the hesse matrix for a whole range of field
   space values at once.
 - Upgraded numpy 0.19 -> 0.20

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@
   compatible with python 3.12 has been released yet. Package still interfaces
   with rust using the stable python 3.7 ABI. This will not be changed until
   the 3.7 ABI is deprecated. 
+- Added `hesse_array` method that allows calculating the hesse matrix (for an
+  arbitrary number of field-space dimensions) at all points in a given field-
+  space array.
 - Upgraded numpy 0.19 -> 0.20
 - Upgraded PyO3 0.19 -> 0.20
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Inflatox Changelog
 
+### v0.6.0
+- Specified that package is only compatible with python 3.7 - 3.11, because
+  no version of `Numba` dependency (which is a dependency of EinsteinPy) that is
+  compatible with python 3.12 has been released yet. Package still interfaces
+  with rust using the stable python 3.7 ABI. This will not be changed until
+  the 3.7 ABI is deprecated. 
+- Upgraded numpy 0.19 -> 0.20
+- Upgraded PyO3 0.19 -> 0.20
+
 ## v0.5.0 - Quantum diffusion
 - breaking ABI change (new symbols)
 - added functionality to calculate if gradient of potential flips sign (goes to

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -89,6 +89,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a357d28ed41a50f9c765dbfe56cbc04a64e53e5fc58ba79fbc34c10ef3df831f"
 
 [[package]]
+name = "heck"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "95505c38b4572b2d910cecb0281560f54b440a19336cbbcb27bf6ce6adc6f5a8"
+
+[[package]]
 name = "hermit-abi"
 version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -114,9 +120,9 @@ dependencies = [
 
 [[package]]
 name = "indoc"
-version = "1.0.9"
+version = "2.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bfa799dd5ed20a7e349f3b4639aa80d74549c81716d9ec4f994c9b5815598306"
+checksum = "1e186cfbae8084e513daff4240b4797e342f988cecda4fb6c939150f96315fd8"
 
 [[package]]
 name = "instant"
@@ -258,9 +264,9 @@ checksum = "830b246a0e5f20af87141b25c173cd1b609bd7779a4617d6ec582abaf90870f3"
 
 [[package]]
 name = "numpy"
-version = "0.19.0"
+version = "0.20.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "437213adf41bbccf4aeae535fbfcdad0f6fed241e1ae182ebe97fa1f3ce19389"
+checksum = "bef41cbb417ea83b30525259e30ccef6af39b31c240bda578889494c5392d331"
 dependencies = [
  "libc",
  "ndarray",
@@ -317,9 +323,9 @@ dependencies = [
 
 [[package]]
 name = "pyo3"
-version = "0.19.0"
+version = "0.20.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cffef52f74ec3b1a1baf295d9b8fcc3070327aefc39a6d00656b13c1d0b8885c"
+checksum = "04e8453b658fe480c3e70c8ed4e3d3ec33eb74988bd186561b0cc66b85c3bc4b"
 dependencies = [
  "cfg-if",
  "indoc",
@@ -334,9 +340,9 @@ dependencies = [
 
 [[package]]
 name = "pyo3-build-config"
-version = "0.19.0"
+version = "0.20.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "713eccf888fb05f1a96eb78c0dbc51907fee42b3377272dc902eb38985f418d5"
+checksum = "a96fe70b176a89cff78f2fa7b3c930081e163d5379b4dcdf993e3ae29ca662e5"
 dependencies = [
  "once_cell",
  "target-lexicon",
@@ -344,9 +350,9 @@ dependencies = [
 
 [[package]]
 name = "pyo3-ffi"
-version = "0.19.0"
+version = "0.20.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b2ecbdcfb01cbbf56e179ce969a048fd7305a66d4cdf3303e0da09d69afe4c3"
+checksum = "214929900fd25e6604661ed9cf349727c8920d47deff196c4e28165a6ef2a96b"
 dependencies = [
  "libc",
  "pyo3-build-config",
@@ -354,9 +360,9 @@ dependencies = [
 
 [[package]]
 name = "pyo3-macros"
-version = "0.19.0"
+version = "0.20.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b78fdc0899f2ea781c463679b20cb08af9247febc8d052de941951024cd8aea0"
+checksum = "dac53072f717aa1bfa4db832b39de8c875b7c7af4f4a6fe93cdbf9264cf8383b"
 dependencies = [
  "proc-macro2",
  "pyo3-macros-backend",
@@ -366,10 +372,11 @@ dependencies = [
 
 [[package]]
 name = "pyo3-macros-backend"
-version = "0.19.0"
+version = "0.20.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "60da7b84f1227c3e2fe7593505de274dcf4c8928b4e0a1c23d551a14e4e80a0f"
+checksum = "7774b5a8282bd4f25f803b1f0d945120be959a36c72e08e7cd031c792fdfd424"
 dependencies = [
+ "heck",
  "proc-macro2",
  "quote",
  "syn",
@@ -441,9 +448,9 @@ checksum = "a507befe795404456341dfab10cef66ead4c041f62b8b11bbb92bffe5d0953e0"
 
 [[package]]
 name = "syn"
-version = "1.0.109"
+version = "2.0.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "72b64191b275b66ffe2469e8af2c1cfe3bafa67b529ead792a6d0160888b4237"
+checksum = "a6f671d4b5ffdb8eadec19c0ae67fe2639df8684bd7bc4b83d986b8db549cf01"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -476,9 +483,9 @@ checksum = "e51733f11c9c4f72aa0c160008246859e340b00807569a0da0e7a1079b27ba85"
 
 [[package]]
 name = "unindent"
-version = "0.1.11"
+version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e1766d682d402817b5ac4490b3c3002d91dfa0d22812f341609f97b08757359c"
+checksum = "c7de7d73e1754487cb58364ee906a499937a0dfabd86bcb980fa99ec8c8fa2ce"
 
 [[package]]
 name = "windows-sys"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,8 +32,8 @@ crate_type = ["cdylib", "rlib"]
 
 [dependencies]
 ndarray = { version = "0.15", features = ['rayon'] }
-numpy = "0.19"
-pyo3 = { version = "0.19", features = ['extension-module', 'abi3-py37'] }
+numpy = "0.20"
+pyo3 = { version = "0.20", features = ['extension-module', 'abi3-py37'] }
 rayon = "1"
 libloading = "0.8"
 indicatif = { version = "0.17", features = ["rayon",  "improved_unicode"] }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,7 +19,7 @@
 
 [project]
 name = "inflatox"
-version = "0.5.0"
+version = "0.6.0"
 authors = [
   { name="Raúl Wolters", email="rawolters11@gmail.com" },
 ]

--- a/python/inflatox/compiler.py
+++ b/python/inflatox/compiler.py
@@ -242,7 +242,7 @@ double g{idx}(const double x[], const double args[]) {{
       #(6) Write the size of the gradient
       gradnorm_body = ccode_writer.doprint(self.symbolic_out.gradient_size).replace(')*', ') *\n    ')
       out.write(f"""
-double grad_norm(const double x[], const double args[]) {{
+double grad_norm_squared(const double x[], const double args[]) {{
   return {gradnorm_body};
 }}          
 """)

--- a/python/inflatox/compiler.py
+++ b/python/inflatox/compiler.py
@@ -222,7 +222,6 @@ double V(const double x[], const double args[]) {{
   return {potential_body};
 }}
 """)
-      
       #(4) Write all the components of the Hesse matrix
       for a in range(self.symbolic_out.dim):
         for b in range(self.symbolic_out.dim):
@@ -232,7 +231,6 @@ double v{a}{b}(const double x[], const double args[]) {{
   return {function_body};
 }}
 """)
-          
       #(5) Write all the components of the first basis vector (gradient)
       for (idx, cmp) in enumerate(self.symbolic_out.basis[0]):
         function_body = ccode_writer.doprint(cmp).replace(')*', ') *\n    ')
@@ -241,8 +239,15 @@ double g{idx}(const double x[], const double args[]) {{
   return {function_body};
 }}
 """)
+      #(6) Write the size of the gradient
+      gradnorm_body = ccode_writer.doprint(self.symbolic_out.gradient_size).replace(')*', ') *\n    ')
+      out.write(f"""
+double grad_norm(const double x[], const double args[]) {{
+  return {gradnorm_body};
+}}          
+""")
           
-      #(6) Write global constants
+      #(7) Write global constants
       v = __abi_version__.split('.')
       out.write(f"""
 //Inflatox version used to generate this file
@@ -255,7 +260,7 @@ const uint32_t N_PARAMTERS = {len(ccode_writer.param_dict)};
 char *const MODEL_NAME = \"{self.symbolic_out.model_name}\";
 """)
       
-    #(6) Update symbol dictionary
+    #(8) Update symbol dictionary
     self.symbol_dict = ccode_writer.coord_dict
     self.symbol_dict.update(ccode_writer.param_dict)
   

--- a/python/inflatox/compiler.py
+++ b/python/inflatox/compiler.py
@@ -240,7 +240,7 @@ double g{idx}(const double x[], const double args[]) {{
 }}
 """)
       #(6) Write the size of the gradient
-      gradnorm_body = ccode_writer.doprint(self.symbolic_out.gradient_size).replace(')*', ') *\n    ')
+      gradnorm_body = ccode_writer.doprint(self.symbolic_out.gradient_square).replace(')*', ') *\n    ')
       out.write(f"""
 double grad_norm_squared(const double x[], const double args[]) {{
   return {gradnorm_body};

--- a/python/inflatox/consistency_conditions.py
+++ b/python/inflatox/consistency_conditions.py
@@ -305,24 +305,22 @@ class AnguelovaLazaroiuCondition(InflationCondition):
     x1_stop: float,
     N_x0: int = 10_000,
     N_x1: int = 10_000,
-    threshold: float = 1e-2,
     progress = True
   ) -> np.ndarray:
     """Evaluates the turn rate ω for the field-space region specified by the
-    start/stop arguments given the model parameters. ω cannot be calculated for
-    any field-space point, only for those where |δ|<<1. At points where 
-    |δ| is not smaller than the `threshold` parameter, a `NaN` value will be
-    returned.
+    start/stop arguments given the model parameters, assuming that all slow-roll
+    parameters are small.
     
     ### Precise mathematical formulation
-    ω is calculated by assuming that the gradient and potential bases are
-    counter-aligned, which is approximately the case for |δ|<<1. With this
-    assumption, ω can be written as:
+    When the slow-roll parameters are zero, ω can be written as:
     
-      Vww / V = ω²/3
+      Vtt / V = ω²/3
       
     In this range, we can thus calculate ω from the potential and field-space
-    metric alone. See [publication] for more details and examples.
+    metric alone. See [publication] for more details and examples. Vtt is written
+    in terms of Vvv, Vvw and Vww using the angle δ:
+  
+    Vtt = cos²δ Vww + sin²δ -2sinδ cosδ Vvw
 
     ### Args
     - `args` (`np.ndarray`): values of the model-dependent parameters. 
@@ -332,9 +330,6 @@ class AnguelovaLazaroiuCondition(InflationCondition):
     - `y_stop` (`float`): maximum value of second field `x[1]`.
     - `N_x` (`int`, optional): number of steps along `x[0]` axis. Defaults to 10_000.
     - `x1_stop` (`int`, optional): number of steps along `x[1]` axis. Defaults to 10_000.
-    - `threshold` (`float`, optional): threshold above which the calculated value
-      for ω should be discarded. Note that increasing this number will _not_
-      extend the validity range of approximation underlying the calculation.
     - `progress` (`bool`, optional): whether to render a progressbar or not. Showing the
       progressbar may slightly degrade performance. Defaults to True.
 
@@ -350,7 +345,7 @@ class AnguelovaLazaroiuCondition(InflationCondition):
     ])
     
     #evaluate and return
-    omega_py(self.dylib, args, x, start_stop, threshold, progress)
+    omega_py(self.dylib, args, x, start_stop, progress)
     return x
   
   def flag_quantum_dif(self,

--- a/python/inflatox/consistency_conditions.py
+++ b/python/inflatox/consistency_conditions.py
@@ -84,7 +84,7 @@ class InflationCondition():
     """
     n_fields = self.artifact.n_fields
     start_stop = np.array([[start, stop] for (start, stop) in zip(start, stop)])
-    N = N if N is not None else np.array([8000 for _ in range(n_fields)])
+    N = N if N is not None else (8000 for _ in range(n_fields))
     x = np.zeros(N)
     self.dylib.potential_array(x, args, start_stop)
     return x

--- a/python/inflatox/consistency_conditions.py
+++ b/python/inflatox/consistency_conditions.py
@@ -104,6 +104,40 @@ class InflationCondition():
       parameters `args` at coordinates `x`.
     """
     return self.dylib.hesse(x, args)
+  
+  def calc_H_array(self,
+    args: list[float] | np.ndarray,
+    start: list[float] | np.ndarray,
+    stop: list[float] | np.ndarray,
+    N: list[int] | None = None
+  ) -> np.ndarray:
+    """constructs an array of field space coordinates and fills it with the
+    value of the projected Hesse matrix at those field space coordinates.
+    The start and stop values of each axis in field-space can be specified with
+    the `start` and `stop` arguments. The number of samples along each axis can
+    be set with the `N` argument. It defaults to `8000` per axis.
+
+    ### Args
+    - `args` (`list[float] | np.ndarray`): values of the model-dependent
+    parameters. See `CompilationArtifact.print_sym_lookup_table()` for an
+    overview of which sympy symbols were mapped to which args index.
+    - `start` (`list[float] | np.ndarray`): list of minimum values for
+    each axis of the to-be-constructed array in field space.
+    - `stop` (`list[float] | np.ndarray`): list of maximum values for each
+    axis of the to-be-constructed array in field space.
+    - `N` (`list[int] | None`, optional): _description_. list of the number of
+    samples along each axis in field space. If set to `None`, 8000 samples will
+    be used along each axis.
+
+    ### Returns
+    `np.ndarray`: (d+2)-dimensional array for a d-dimensional field-space. The
+      first two axes of this array represent the axes of the Hesse matrix itself.
+      The other axes correspond to the field-space components. 
+    """
+    n_fields = self.artifact.n_fields
+    start_stop = np.array([[start, stop] for (start, stop) in zip(start, stop)])
+    N = N if N is not None else (8000 for _ in range(n_fields))
+    return self.dylib.hesse_array(N, args, start_stop)
 
 class AnguelovaLazaroiuCondition(InflationCondition):
   """This class extends the generic `InflationCondition` with the potential

--- a/python/inflatox/consistency_conditions.py
+++ b/python/inflatox/consistency_conditions.py
@@ -23,7 +23,7 @@ import numpy as np
 
 #Internal imports
 from .compiler import CompilationArtifact
-from .libinflx_rs import (open_inflx_dylib, anguelova_py, delta_py, flag_quantum_dif_py)
+from .libinflx_rs import (open_inflx_dylib, anguelova_py, delta_py, omega_py, flag_quantum_dif_py)
 
 #Limit exports to these items
 __all__ = ['InflationCondition', 'AnguelovaLazaroiuCondition']
@@ -261,6 +261,62 @@ class AnguelovaLazaroiuCondition(InflationCondition):
     
     #evaluate and return
     delta_py(self.dylib, args, x, start_stop, progress)
+    return x
+  
+  def calc_omega(self,
+    args: np.ndarray,
+    x0_start: float,
+    x0_stop: float,
+    x1_start: float,
+    x1_stop: float,
+    N_x0: int = 10_000,
+    N_x1: int = 10_000,
+    threshold: float = 1e-2,
+    progress = True
+  ) -> np.ndarray:
+    """Evaluates the turn rate ω for the field-space region specified by the
+    start/stop arguments given the model parameters. ω cannot be calculated for
+    any field-space point, only for those where |δ|<<1. At points where 
+    |δ| is not smaller than the `threshold` parameter, a `NaN` value will be
+    returned.
+    
+    ### Precise mathematical formulation
+    ω is calculated by assuming that the gradient and potential bases are
+    counter-aligned, which is approximately the case for |δ|<<1. With this
+    assumption, ω can be written as:
+    
+      Vww / V = ω²/3
+      
+    In this range, we can thus calculate ω from the potential and field-space
+    metric alone. See [publication] for more details and examples.
+
+    ### Args
+    - `args` (`np.ndarray`): values of the model-dependent parameters. 
+    - `x0_start` (`float`): minimum value of first field `x[0]`.
+    - `x0_stop` (`float`): maximum value of first field `x[0]`.
+    - `x1_start` (`float`): minimum value of second field `x[1]`.
+    - `y_stop` (`float`): maximum value of second field `x[1]`.
+    - `N_x` (`int`, optional): number of steps along `x[0]` axis. Defaults to 10_000.
+    - `x1_stop` (`int`, optional): number of steps along `x[1]` axis. Defaults to 10_000.
+    - `threshold` (`float`, optional): threshold above which the calculated value
+      for ω should be discarded. Note that increasing this number will _not_
+      extend the validity range of approximation underlying the calculation.
+    - `progress` (`bool`, optional): whether to render a progressbar or not. Showing the
+      progressbar may slightly degrade performance. Defaults to True.
+
+    ### Returns
+    `np.ndarray`: array with calculated ω's
+    """
+    #set up args for anguelova's condition
+    x = np.zeros((N_x0, N_x1))
+    
+    start_stop = np.array([
+      [x0_start, x0_stop],
+      [x1_start, x1_stop]
+    ])
+    
+    #evaluate and return
+    omega_py(self.dylib, args, x, start_stop, threshold, progress)
     return x
   
   def flag_quantum_dif(self,

--- a/python/inflatox/consistency_conditions.py
+++ b/python/inflatox/consistency_conditions.py
@@ -23,7 +23,7 @@ import numpy as np
 
 #Internal imports
 from .compiler import CompilationArtifact
-from .libinflx_rs import (open_inflx_dylib, anguelova_py, delta_py, omega_py, flag_quantum_dif_py)
+from .libinflx_rs import *
 
 #Limit exports to these items
 __all__ = ['InflationCondition', 'AnguelovaLazaroiuCondition']
@@ -346,6 +346,57 @@ class AnguelovaLazaroiuCondition(InflationCondition):
     
     #evaluate and return
     omega_py(self.dylib, args, x, start_stop, progress)
+    return x
+  
+  def calc_epsilon(self,
+    args: np.ndarray,
+    x0_start: float,
+    x0_stop: float,
+    x1_start: float,
+    x1_stop: float,
+    N_x0: int = 10_000,
+    N_x1: int = 10_000,
+    progress = True
+  ) -> np.ndarray:
+    """Evaluates the turn rate ω for the field-space region specified by the
+    start/stop arguments given the model parameters, assuming that all slow-roll
+    parameters are small.
+    
+    ### Precise mathematical formulation
+    When the slow-roll parameters are zero, ω can be written as:
+    
+      Vtt / V = ω²/3
+      
+    In this range, we can thus calculate ω from the potential and field-space
+    metric alone. See [publication] for more details and examples. Vtt is written
+    in terms of Vvv, Vvw and Vww using the angle δ:
+  
+    Vtt = cos²δ Vww + sin²δ -2sinδ cosδ Vvw
+
+    ### Args
+    - `args` (`np.ndarray`): values of the model-dependent parameters. 
+    - `x0_start` (`float`): minimum value of first field `x[0]`.
+    - `x0_stop` (`float`): maximum value of first field `x[0]`.
+    - `x1_start` (`float`): minimum value of second field `x[1]`.
+    - `y_stop` (`float`): maximum value of second field `x[1]`.
+    - `N_x` (`int`, optional): number of steps along `x[0]` axis. Defaults to 10_000.
+    - `x1_stop` (`int`, optional): number of steps along `x[1]` axis. Defaults to 10_000.
+    - `progress` (`bool`, optional): whether to render a progressbar or not. Showing the
+      progressbar may slightly degrade performance. Defaults to True.
+
+    ### Returns
+    `np.ndarray`: array with calculated ω's
+    """
+    #set up args for anguelova's condition
+    x = np.zeros((N_x0, N_x1))
+    
+    start_stop = np.array([
+      [x0_start, x0_stop],
+      [x1_start, x1_stop]
+    ])
+    
+    #evaluate and return
+    epsilon_py(self.dylib, args, x, start_stop, progress)
     return x
   
   def flag_quantum_dif(self,

--- a/python/inflatox/symbolic.py
+++ b/python/inflatox/symbolic.py
@@ -45,7 +45,7 @@ class SymbolicOutput():
     self.coordinates = coordinates
     self.potential = potential
     self.model_name = model_name
-    self.gradient_size = gradient_size
+    self.gradient_square = gradient_size
     if len(hesse_cmp[0]) != len(hesse_cmp):
       raise Exception('The Hesse matrix is square; the provided list was not (number of columns != number of rows)')
     if len(hesse_cmp[0]) != len(basis[0]):
@@ -314,7 +314,7 @@ class SymbolicCalculation():
         
     #(4) Calculate the size of the gradient
     print("Calculating the norm of the gradient...")
-    gradnorm = self.calc_gradient_size()
+    gradnorm = self.calc_gradient_square()
         
     return SymbolicOutput(H_proj, w, self.coords, self.V, gradnorm, self.model_name)
    
@@ -404,7 +404,7 @@ class SymbolicCalculation():
         Vab[a][b] = self.simplify(cmp) if self.simp >= 2 else cmp
     return Vab
   
-  def calc_gradient_size(self) -> sympy.Expr:
+  def calc_gradient_square(self) -> sympy.Expr:
     """Calculates the size of the gradient of the potential given the metric g_ab.
     
     ### Precise formulation of calculated quantities
@@ -420,13 +420,13 @@ class SymbolicCalculation():
     """
     dim = len(self.coords)
     #non-normalised components of grad V
-    v = [sympy.diff(self.V, φ) for φ in self.coords]
-    out = 1 
+    gradient = [sympy.diff(self.V, φ) for φ in self.coords]
+    out = 0.
     
     #contract v with the inverse of the metric tensor
     for a in range(dim):
       for b in range(dim):
-        out +=  self.g.inv().arr[a][b] * v[a] * v[b]
+        out = out + self.g.inv().arr[a][b] * gradient[a] * gradient[b]
     return self.simplify(out) if self.simp >= 2 else out
 
   def calc_v(self) -> list[sympy.Expr]:

--- a/python/inflatox/symbolic.py
+++ b/python/inflatox/symbolic.py
@@ -408,14 +408,15 @@ class SymbolicCalculation():
     """Calculates the size of the gradient of the potential given the metric g_ab.
     
     ### Precise formulation of calculated quantities
-      output(ϕ) = sqrt[g^ab(ϕ) ∂_a V(ϕ) ∂_b V(ϕ)]
+      output(ϕ) = g^ab(ϕ) ∂_a V(ϕ) ∂_b V(ϕ)
+    Note that the output is actual the size of the gradient *squared*.
     
     ### Simplification
     If the simplification depth is set to 2 or higher, this function will
     simplify its output before returning.
 
     Returns:
-        sympy.Expr: _description_
+      sympy.Expr: size of the gradient squared (V_a V^a)
     """
     dim = len(self.coords)
     #non-normalised components of grad V
@@ -426,7 +427,6 @@ class SymbolicCalculation():
     for a in range(dim):
       for b in range(dim):
         out +=  self.g.inv().arr[a][b] * v[a] * v[b]
-    out = sympy.sqrt(out)
     return self.simplify(out) if self.simp >= 2 else out
 
   def calc_v(self) -> list[sympy.Expr]:

--- a/python/inflatox/symbolic.py
+++ b/python/inflatox/symbolic.py
@@ -396,6 +396,31 @@ class SymbolicCalculation():
         cmp = da_dbV - gamma_ab
         Vab[a][b] = self.simplify(cmp) if self.simp >= 2 else cmp
     return Vab
+  
+  def calc_gradient_size(self) -> sympy.Expr:
+    """Calculates the size of the gradient of the potential given the metric g_ab.
+    
+    ### Precise formulation of calculated quantities
+      output(ϕ) = sqrt[g^ab(ϕ) ∂_a V(ϕ) ∂_b V(ϕ)]
+    
+    ### Simplification
+    If the simplification depth is set to 2 or higher, this function will
+    simplify its output before returning.
+
+    Returns:
+        sympy.Expr: _description_
+    """
+    dim = len(self.coords)
+    #non-normalised components of grad V
+    v = [sympy.diff(self.V, φ) for φ in self.coords]
+    out = 1 
+    
+    #contract v with the inverse of the metric tensor
+    for a in range(dim):
+      for b in range(dim):
+        out +=  self.g.inv().arr[a][b] * v[a] * v[b]
+    out = sympy.sqrt(out)
+    return self.simplify(out) if self.simp >= 2 else out
 
   def calc_v(self) -> list[sympy.Expr]:
     """calculates a normalized vector pointing in the direction of the gradient of

--- a/python/inflatox/symbolic.py
+++ b/python/inflatox/symbolic.py
@@ -36,6 +36,7 @@ class SymbolicOutput():
     basis: list[list[sympy.Expr]],
     coordinates: list[sympy.Symbol],
     potential: sympy.Expr,
+    gradient_size: sympy.Expr,
     model_name: str
   ):
     self.hesse_cmp = hesse_cmp
@@ -44,6 +45,7 @@ class SymbolicOutput():
     self.coordinates = coordinates
     self.potential = potential
     self.model_name = model_name
+    self.gradient_size = gradient_size
     if len(hesse_cmp[0]) != len(hesse_cmp):
       raise Exception('The Hesse matrix is square; the provided list was not (number of columns != number of rows)')
     if len(hesse_cmp[0]) != len(basis[0]):
@@ -309,7 +311,12 @@ class SymbolicCalculation():
         if a == 0: a = 'v'
         if b == 0: b = 'v'
         self.display(component, lhs=f'H_{{{a}{b}}}')
-    return SymbolicOutput(H_proj, w, self.coords, self.V, self.model_name)
+        
+    #(4) Calculate the size of the gradient
+    print("Calculating the norm of the gradient...")
+    gradnorm = self.calc_gradient_size()
+        
+    return SymbolicOutput(H_proj, w, self.coords, self.V, gradnorm, self.model_name)
    
   def inner_prod(self, v1: list[sympy.Expr], v2: list[sympy.Expr]) -> sympy.Expr:
     """returns the inner product of v1 and v2 with respect to configured metric.

--- a/python/inflatox/version.py
+++ b/python/inflatox/version.py
@@ -18,4 +18,4 @@
 #  licensee subject to Dutch law as per article 15 of the EUPL.
 
 __version__ = '0.6.0'
-__abi_version__ = '2.0.0'
+__abi_version__ = '3.0.0'

--- a/python/inflatox/version.py
+++ b/python/inflatox/version.py
@@ -17,5 +17,5 @@
 #  (1) Resident of the Kingdom of the Netherlands; agreement between licensor and
 #  licensee subject to Dutch law as per article 15 of the EUPL.
 
-__version__ = '0.5.0'
+__version__ = '0.6.0'
 __abi_version__ = '2.0.0'

--- a/src/anguelova.rs
+++ b/src/anguelova.rs
@@ -419,7 +419,7 @@ pub fn epsilon_py(
     let cos2d = v00.powi(2) / (v00.powi(2) + v01.powi(2));
     let sin2d = v01.powi(2) / (v00.powi(2) + v01.powi(2));
     let sincosd = (v01 * v00) / (v00.powi(2) + v01.powi(2));
-    *val = (0.5 * v.powi(-2)) * (cos2d * grad0.powi(2) + sin2d * grad1.powi(2) + 2.0 * sincosd * grad0 * grad1);
+    *val = 0.5 * (cos2d * (grad0/v).powi(2) + sin2d * (grad1/v).powi(2) + 2.0 * sincosd * grad0 * grad1 * v.powi(-2));
   };
 
   if progress {

--- a/src/anguelova.rs
+++ b/src/anguelova.rs
@@ -96,7 +96,7 @@ pub fn anguelova_py(
   let start_stop = crate::convert_start_stop(start_stop, 2)?;
 
   //(4) Say hello
-  eprintln!("[Inflatox] Starting calculation using {} threads.", rayon::current_num_threads());
+  eprintln!("[Inflatox] Calculating consistency condition using {} threads.", rayon::current_num_threads());
   let _ = std::io::stderr().flush();
   let start = std::time::Instant::now();
 
@@ -299,7 +299,7 @@ pub fn delta_py(
   let start_stop = crate::convert_start_stop(start_stop, 2)?;
 
   //(4) Say hello
-  eprintln!("[Inflatox] Starting calculation using {} threads.", rayon::current_num_threads());
+  eprintln!("[Inflatox] Calculating alignment angle δ using {} threads.", rayon::current_num_threads());
   let _ = std::io::stderr().flush();
   let start = std::time::Instant::now();
 
@@ -349,7 +349,7 @@ pub fn omega_py(
   let start_stop = crate::convert_start_stop(start_stop, 2)?;
 
   //(4) Say hello
-  eprintln!("[Inflatox] Starting calculation using {} threads.", rayon::current_num_threads());
+  eprintln!("[Inflatox] Calculating turn rate ω using {} threads.", rayon::current_num_threads());
   let _ = std::io::stderr().flush();
   let start = std::time::Instant::now();
 
@@ -407,7 +407,7 @@ pub fn flag_quantum_dif_py(
   let start_stop = crate::convert_start_stop(start_stop, 2)?;
 
   //(4) Say hello
-  eprintln!("[Inflatox] Starting calculation using {} threads.", rayon::current_num_threads());
+  eprintln!("[Inflatox] Calculating zeros of the potential gradient using {} threads.", rayon::current_num_threads());
   let _ = std::io::stderr().flush();
   let start = std::time::Instant::now();
 

--- a/src/anguelova.rs
+++ b/src/anguelova.rs
@@ -259,8 +259,9 @@ fn anguelova_exact(
   let op = |(ref x, val): ([f64; 2], &mut f64)| {
     *val = {
       let (v, v00, v10, v11) = (h.potential(x, p), h.v00(x, p), h.v10(x, p), h.v11(x, p));
-      let delta = (v10 / v00).atan();
-      let lhs = 3.0 * delta.sin().powi(-2) + v10.powi(2) / (v * v00);
+      let tan2_delta = (v10 / v00).powi(2);
+      let csc2_delta = 1.0 + tan2_delta.recip(); //csc²(x) = 1 + cot²(x)
+      let lhs = 3.0 * csc2_delta + (v00 / v) * tan2_delta;
       let rhs = v11 / v;
       ((lhs / rhs) - 1.0).abs()
     }

--- a/src/anguelova.rs
+++ b/src/anguelova.rs
@@ -419,14 +419,14 @@ pub fn epsilon_py(
     let cos2d = v00.powi(2) / (v00.powi(2) + v01.powi(2));
     let sin2d = v01.powi(2) / (v00.powi(2) + v01.powi(2));
     let sincosd = (v01 * v00) / (v00.powi(2) + v01.powi(2));
-    let vtt = cos2d * v11 + sin2d * v00 - 2.0 * sincosd * v01;
-    let omega2_by3 = (3.0 * vtt / v).abs();
+    let vtt_byv = cos2d * (v11/v) + sin2d * (v00/v) - 2.0 * sincosd * (v01/v);
+    let omega2_by9 = (vtt_byv / 3.0).abs();
 
     //Calculate epsilon_V
     let epsilon_v = grad.grad_square(x, p) / (2.0 * v.powi(2));
 
     //Calculate epsilon
-    *val = epsilon_v / (1. + omega2_by3 / 3.0);
+    *val = epsilon_v / (1. + omega2_by9);
   };
 
   if progress {

--- a/src/anguelova.rs
+++ b/src/anguelova.rs
@@ -325,7 +325,10 @@ pub fn delta_py(
 }
 
 #[pyfunction]
-/// boo
+/// python-facing function used to calculate the relative turn rate omega given
+/// the supplied input field-space array and the parameter array p. The order of
+/// the calculation may be specified using the order parameter. Console output
+/// will be generated if progress=true.
 pub fn omega_py(
   lib: PyRef<crate::InflatoxPyDyLib>,
   p: PyReadonlyArray1<f64>,

--- a/src/hesse_bindings.rs
+++ b/src/hesse_bindings.rs
@@ -22,7 +22,6 @@
 use std::{ffi::{OsStr, c_char}, mem::MaybeUninit};
 
 use ndarray as nd;
-use nd::parallel::prelude::*;
 
 use crate::inflatox_version::InflatoxVersion;
 

--- a/src/hesse_bindings.rs
+++ b/src/hesse_bindings.rs
@@ -390,4 +390,11 @@ impl<'a> Grad<'a> {
     assert!(p.len() == self.lib.get_n_params());
     unsafe { self.fns[idx](x as *const [f64] as *const f64, p as *const [f64] as *const f64) }
   }
+
+  #[inline]
+  pub fn grad_square(&self, x: &[f64], p: &[f64]) -> f64 {
+    assert!(x.len() == self.lib.get_n_fields());
+    assert!(p.len() == self.lib.get_n_params());
+    unsafe { (self.lib.grad_square)(x as *const [f64] as *const f64, p as *const [f64] as *const f64) }
+  }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -49,6 +49,7 @@ fn libinflx_rs(py: Python<'_>, pymod: &PyModule) -> PyResult<()> {
   pymod.add_function(wrap_pyfunction!(anguelova::anguelova_py, pymod)?)?;
   pymod.add_function(wrap_pyfunction!(anguelova::delta_py, pymod)?)?;
   pymod.add_function(wrap_pyfunction!(anguelova::omega_py, pymod)?)?;
+  pymod.add_function(wrap_pyfunction!(anguelova::epsilon_py, pymod)?)?;
   pymod.add_function(wrap_pyfunction!(anguelova::flag_quantum_dif_py, pymod)?)?;
 
   //Register exceptions

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -36,7 +36,7 @@ use numpy::{PyArray2, PyReadonlyArray1, PyReadonlyArray2, PyReadonlyArrayDyn, Py
 use pyo3::{create_exception, exceptions::PyException, prelude::*};
 
 /// Version of Inflatox ABI that this crate is compatible with
-pub const V_INFLX_ABI: InflatoxVersion = InflatoxVersion::new([2, 0, 0]);
+pub const V_INFLX_ABI: InflatoxVersion = InflatoxVersion::new([3, 0, 0]);
 
 //Register errors
 create_exception!(libinflx_rs, ShapeError, PyException);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -48,6 +48,7 @@ fn libinflx_rs(py: Python<'_>, pymod: &PyModule) -> PyResult<()> {
   pymod.add_function(wrap_pyfunction!(open_inflx_dylib, pymod)?)?;
   pymod.add_function(wrap_pyfunction!(anguelova::anguelova_py, pymod)?)?;
   pymod.add_function(wrap_pyfunction!(anguelova::delta_py, pymod)?)?;
+  pymod.add_function(wrap_pyfunction!(anguelova::omega_py, pymod)?)?;
   pymod.add_function(wrap_pyfunction!(anguelova::flag_quantum_dif_py, pymod)?)?;
 
   //Register exceptions


### PR DESCRIPTION
- Specified that package is only compatible with python 3.7 - 3.11, because
  no version of `Numba` dependency (which is a dependency of EinsteinPy) that is
  compatible with python 3.12 has been released yet. Package still interfaces
  with rust using the stable python 3.7 ABI. This will not be changed until
  the 3.7 ABI is deprecated. 
- Added `hesse_array` method that allows calculating the hesse matrix (for an
  arbitrary number of field-space dimensions) at all points in a given field-
  space array.
- added functionality to calculate the turn rate $\omega$ under the assumption
  that the slow-roll parameters are small.
- added functionality to calculate the hesse matrix for a whole range of field
  space values at once.
- Upgraded numpy 0.19 -> 0.20
- Upgraded PyO3 0.19 -> 0.20